### PR TITLE
Suppress errors from log in favor of printing them in debug mode only

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -88,7 +88,7 @@ export class FlairPlatform implements DynamicPlatformPlugin {
         const structure = await this.client.getStructure(await this.getStructure());
         this.updateStructureFromStructureReading(structure);
       } catch (e) {
-        this.log.error(e);
+        this.log.debug(e);
       }
     }
 

--- a/src/puckPlatformAccessory.ts
+++ b/src/puckPlatformAccessory.ts
@@ -65,7 +65,7 @@ export class FlairPuckPlatformAccessory {
         this.updatePuckReadingsFromPuck(puck);
         return puck;
       } catch (e) {
-        this.platform.log.error(e);
+        this.platform.log.debug(e);
       }
 
       return this.puck;

--- a/src/roomPlatformAccessory.ts
+++ b/src/roomPlatformAccessory.ts
@@ -121,7 +121,7 @@ export class FlairRoomPlatformAccessory {
         this.updateRoomReadingsFromRoom(room);
         return room;
       } catch (e) {
-        this.platform.log.error(e);
+        this.platform.log.debug(e);
       }
 
       return this.room;

--- a/src/ventPlatformAccessory.ts
+++ b/src/ventPlatformAccessory.ts
@@ -177,7 +177,7 @@ export class FlairVentPlatformAccessory {
         this.updateVentReadingsFromVent(vent);
         return vent;
       } catch (e) {
-        this.platform.log.error(e);
+        this.platform.log.debug(e);
       }
 
       return this.vent;


### PR DESCRIPTION
Not sure if this is the best way to handle the logs constantly getting spammed with seemingly non-fatal errors originating from the axios dependency, but this does address the issue.

This should resolve issue #4 