### PR TITLE
fix(homebridgeupdate): convert firmware revision to a string to conform to Homebridge requirements

### DIFF
--- a/src/puckPlatformAccessory.ts
+++ b/src/puckPlatformAccessory.ts
@@ -79,7 +79,7 @@ export class FlairPuckPlatformAccessory {
       this.humidityService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.puck.currentHumidity);
 
       this.accessory.getService(this.platform.Service.AccessoryInformation)!
-        .updateCharacteristic(this.platform.Characteristic.FirmwareRevision, this.puck.firmwareVersionS);
+        .updateCharacteristic(String(this.platform.Characteristic.FirmwareRevision), this.puck.firmwareVersionS);
 
       this.platform.log.debug(`Pushed updated current temperature state for ${this.puck.name!} to HomeKit:`, this.puck.currentTemperatureC);
     }

--- a/src/ventPlatformAccessory.ts
+++ b/src/ventPlatformAccessory.ts
@@ -228,7 +228,7 @@ export class FlairVentPlatformAccessory {
 
 
       this.accessoryInformationService.updateCharacteristic(
-        this.platform.Characteristic.FirmwareRevision,
+        String(this.platform.Characteristic.FirmwareRevision),
         this.vent.firmwareVersionS,
       );
 


### PR DESCRIPTION
Homebridge beta currently warns the value needs to be a string and indicate using a different type will throw an error in future releases.